### PR TITLE
ci(set-output): use env var and not old untrusted data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |
-          echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
+          echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> $GITHUB_OUTPUT
 
       - name: Detect and tag new version
         id: check-version


### PR DESCRIPTION
Warning from
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.